### PR TITLE
Fix spurious execution of other conditional branches after a true ELSEIF

### DIFF
--- a/semantic.c
+++ b/semantic.c
@@ -4476,7 +4476,10 @@ static void ProcessStatement(SemanticState *state, Statement *statement, const c
 					if (state->true_already_found || value == 0)
 						state->false_if_level = state->current_if_level;
 					else
+					{
 						state->false_if_level = 0;
+						state->true_already_found = cc_true;
+					}
 				}
 			}
 

--- a/semantic.c
+++ b/semantic.c
@@ -4474,7 +4474,9 @@ static void ProcessStatement(SemanticState *state, Statement *statement, const c
 
 					/* If this condition is false, then mark this as the false if-level. */
 					if (state->true_already_found || value == 0)
+					{
 						state->false_if_level = state->current_if_level;
+					}
 					else
 					{
 						state->false_if_level = 0;


### PR DESCRIPTION
state->true_already_found is only being set for IF statements, not ELSEIF, causing various issues with subsequent branches being executed when they're not supposed to. This fix changes the behavior of ELSEIF to match IF in this regard, which I believe should solve the problem (though I haven't tested this for more complex nested constructions).

**Example 1**
```
  if 0
    inform 0,"took IF branch"
  elseif 1
    inform 0,"took ELSEIF branch 1"
  elseif 1
    inform 0,"took ELSEIF branch 2"
  else
    inform 0,"took ELSE branch"
  endif
```
Output on mainline:
```
INFORM: 'took ELSEIF branch 1'
INFORM: 'took ELSEIF branch 2'
```
Output with this fix:
```
INFORM: 'took ELSEIF branch 1'
```

**Example 2**
```
  if 0
    inform 0,"took IF branch"
  elseif 1
    inform 0,"took ELSEIF branch 1"
  elseif 0
    inform 0,"took ELSEIF branch 2"
  else
    inform 0,"took ELSE branch"
  endif
```
Output on mainline:
```
INFORM: 'took ELSEIF branch 1'
INFORM: 'took ELSE branch'
```
Output with this fix:
```
INFORM: 'took ELSEIF branch 1'
```