### PR TITLE
Correctly link new nodes into linked list, fixing sporadic missing symbols in symbol file

### DIFF
--- a/dictionary.c
+++ b/dictionary.c
@@ -315,6 +315,8 @@ cc_bool Dictionary_LookUpAndCreateIfNotExist(Dictionary_State *state, const char
 
 			/* Insert node at start of current bucket's linked list. */
 			new_node->next = bucket->linked_list;
+			if (new_node->next != NULL)
+				new_node->next->previous = new_node;
 			bucket->linked_list = new_node;
 
 			if (entry_pointer != NULL)

--- a/dictionary.c
+++ b/dictionary.c
@@ -315,9 +315,10 @@ cc_bool Dictionary_LookUpAndCreateIfNotExist(Dictionary_State *state, const char
 
 			/* Insert node at start of current bucket's linked list. */
 			new_node->next = bucket->linked_list;
+			bucket->linked_list = new_node;
+
 			if (new_node->next != NULL)
 				new_node->next->previous = new_node;
-			bucket->linked_list = new_node;
 
 			if (entry_pointer != NULL)
 				*entry_pointer = &new_node->entry;


### PR DESCRIPTION
When adding to a linked list, the "previous" field of the old first node is not set to the new node and instead left at NULL. This means that when a node is removed, the code in RemoveNodeFromBucket() will always treat it as though it were at the head of the list, with any nodes before it dropped. Since the search tree is correctly updated, this doesn't directly impact assembly, but sometimes causes symbols to "randomly" go missing from the symbol file. This fix simply sets the "previous" field as intended.

As an example, on mainline, building the Sonic Spinball disassembly in the tests directory produces a 141375-byte symbol file. With this fix, it produces a larger 142305-byte file that contains additional symbols that were being lost, such as "loc_F8422f".